### PR TITLE
Update Life cycle section with information from https://www.suse.com/de-de/support/policy-products/

### DIFF
--- a/xml/cha_images.xml
+++ b/xml/cha_images.xml
@@ -478,8 +478,8 @@
    <listitem>
     <para>
      Images are refreshed every three months. The new images replace the old
-     images in the exact state they were in. Replaced images are immediately
-     moving to the <literal>deprecated</literal> state.
+     images in the exact state they were in. Replaced images are moved to the
+     <literal>deprecated</literal> state.
     </para>
    </listitem>
    <listitem>

--- a/xml/cha_images.xml
+++ b/xml/cha_images.xml
@@ -470,22 +470,62 @@
  <sect1 xml:id="sec-images-lifecycle">
   <title>Lifecycle of images</title>
   <para>
-   In the event of severe security vulnerabilities disclosed through the Common
-   Vulnerabilities and Exposures process (CVE), the &suse; public cloud
-   development team will refresh on-demand base images to ensure that new
-   instances launch in a patched state. This is in addition to the updates
-   available through the &suse; maintained update infrastructure.
+   All &suse; public cloud images follow a refresh cycle up to the point of
+   deletion. The refresh cycle follows a 'rolling' three month time frame. What
+   this means:
   </para>
+  <itemizedlist>
+   <listitem>
+    <para>
+     Images are refreshed every three months. The new images replace the old
+     images in the exact state they were in. Replaced images are immediately
+     moving to the <literal>deleted</literal> state.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     If a security vulnerability occurs during the three months that needs to be
+     addressed, all affected images are updated immediately and the three month
+     timer restarts with this forced replacement.
+    </para>
+    <para>
+     &suse; is committed to address all security vulnerabilities disclosed
+     through the <literal>Common Vulnerabilities and Exposures process</literal>
+     (CVE) and a score of 9.0 or greater in the <literal>Common Vulnerability
+      Scoring System</literal> (CVSS). For more information about the effects and
+     rating of CVEs, refer to the <link
+      xlink:href="https://www.suse.com/security/cve/">&suse; CVE database</link>.
+    </para>
+    <!-- alternative version
+    <para>
+     In the event of a severe security vulnerability disclosed through the 
+     <literal>Common Vulnerabilities and Exposures</literal> (CVE) process, the
+     &suse; public cloud development team will refresh all affected images to
+     ensure that new instances launch in a patched state.
+    </para>
+    <para>
+     In this context, severe security vulnerabilities are defined as CVEs with a
+     score of 9.0 or greater in the <literal>Common Vulnerability Scoring
+     System</literal> (CVSS). For more information about the effects and rating
+     of CVEs, refer to the <link
+     xlink:href="https://www.suse.com/security/cve/">&suse; CVE database</link>.
+    </para>
+    -->
+   </listitem>
+  </itemizedlist>
+
   <para>
-   Information about the effects of CVEs can always be found in the <link
-    xlink:href="https://www.suse.com/security/cve/">&suse; CVE database</link>.
+   The life cycle of an image consists of four different states:
   </para>
   <variablelist>
+   <title>&suse; public cloud image states</title>
    <varlistentry>
     <term>Active</term>
     <listitem>
      <para>
-      Active images are on a three month rolling refresh cycle.
+      Active images are fully supported and refreshed at least every three
+      months. The duration lasts until the image is replaced by a newer image
+      version.
      </para>
     </listitem>
    </varlistentry>
@@ -493,7 +533,10 @@
     <term>Inactive</term>
     <listitem>
      <para>
-      Inactive images will only get refreshed for critical security updates.
+      Inactive images are supported unter the rules of LTSS and will only get
+      refreshed for critical security updates. The duration term is defined by
+      the product. For more information, refer to <link
+       xlink:href="https://www.suse.com/de-de/support/policy-products/#cloud"/>
      </para>
     </listitem>
    </varlistentry>
@@ -501,9 +544,9 @@
     <term>Deprecated</term>
     <listitem>
      <para>
-      Deprecated images do not get refreshed. Images in the deprecated state
-      have entered the last six months of their life-cycle and are subject to
-      removal at the end of the six months period.
+      Deprecated images are no longer supported as they have entered the last
+      six months of their life cycle. They do not get refreshed and are subject
+      to deletion at the end of the six month period.
      </para>
     </listitem>
    </varlistentry>
@@ -511,14 +554,17 @@
     <term>Deleted</term>
     <listitem>
      <para>
-      Deleted images are no longer available for new instances.
+      Deleted images are no longer supported or available for new instances.
      </para>
     </listitem>
    </varlistentry>
   </variablelist>
- <para>
-  It is recommended to only use active images to launch instances for new
-  deployments.
- </para>
+  <important>
+   <title>Only use active images for new instances</title>
+   <para>
+    It is recommended to only use <literal>active</literal> images to launch
+    instances for new deployments.
+   </para>
+  </important>
  </sect1>
 </chapter>

--- a/xml/cha_images.xml
+++ b/xml/cha_images.xml
@@ -479,14 +479,16 @@
     <para>
      Images are refreshed every three months. The new images replace the old
      images in the exact state they were in. Replaced images are immediately
-     moving to the <literal>deleted</literal> state.
+     moving to the <literal>deprecated</literal> state.
     </para>
    </listitem>
    <listitem>
     <para>
      If a security vulnerability occurs during the three months that needs to be
-     addressed, all affected images are updated immediately and the three month
-     timer restarts with this forced replacement.
+     addressed, affected images in <literal>active</literal> and
+     <literal>inactive</literal> states are updated as soon as possible once the
+     fix for the affected code is available. The three month timer restarts with
+     this forced replacement.
     </para>
     <para>
      &suse; is committed to address all security vulnerabilities disclosed
@@ -498,10 +500,12 @@
     </para>
     <!-- alternative version
     <para>
-     In the event of a severe security vulnerability disclosed through the 
+     In the event of a severe security vulnerability disclosed through the
      <literal>Common Vulnerabilities and Exposures</literal> (CVE) process, the
-     &suse; public cloud development team will refresh all affected images to
-     ensure that new instances launch in a patched state.
+     &suse; public cloud development team will refresh affected images in
+     <literal>active</literal> and <literal>inactive</literal> states to ensure
+     that new instances launch in a patched state. The three month timer
+     restarts with this forced replacement.
     </para>
     <para>
      In this context, severe security vulnerabilities are defined as CVEs with a
@@ -533,9 +537,9 @@
     <term>Inactive</term>
     <listitem>
      <para>
-      Inactive images are supported unter the rules of LTSS and will only get
-      refreshed for critical security updates. The duration term is defined by
-      the product. For more information, refer to <link
+      Inactive images are supported following the rules of LTSS or ESPOS and
+      will only get refreshed for critical security updates. The duration term
+      is defined by the product. For more information, refer to <link
        xlink:href="https://www.suse.com/de-de/support/policy-products/#cloud"/>
      </para>
     </listitem>
@@ -544,9 +548,13 @@
     <term>Deprecated</term>
     <listitem>
      <para>
-      Deprecated images are no longer supported as they have entered the last
-      six months of their life cycle. They do not get refreshed and are subject
-      to deletion at the end of the six month period.
+      Deprecated images may no longer be supported. The status of support
+      depends on the support status of the product in the image. Deprecated
+      images are not made available in regions added after an image has been set
+      to <literal>deprecated</literal> and images do no longer get refreshed. At
+      the end of the six month deprecation period, images are subject to
+      deletion. It is strongly discouraged to use deprecated images to create
+      new instances.
      </para>
     </listitem>
    </varlistentry>
@@ -554,16 +562,16 @@
     <term>Deleted</term>
     <listitem>
      <para>
-      Deleted images are no longer supported or available for new instances.
+      Deleted images are no longer supported or available for instance creation.
      </para>
     </listitem>
    </varlistentry>
   </variablelist>
   <important>
-   <title>Only use active images for new instances</title>
+   <title>Only use <literal>active</literal> images for new instances</title>
    <para>
-    It is recommended to only use <literal>active</literal> images to launch
-    instances for new deployments.
+    It is strongly recommended to only use <literal>active</literal> images to
+    launch instances for new deployments.
    </para>
   </important>
  </sect1>


### PR DESCRIPTION
This is an attempt to merge the information from https://www.suse.com/c/suse-public-cloud-image-life-cycle/#cloud with https://www.suse.com/de-de/support/policy-products/#cloud

Some information is still subject to review as there are notable differences between the two documents. For example, the blog post says that deprecated images are no longer refreshed while the support policy document claims that do for important security vulnerabilities. @kvanderveer, please assign this to somebody from your team for a _careful_ review. It'll probably take a few iterations to get everything right.

This should also address: 

* https://bugzilla.suse.com/show_bug.cgi?id=1191845
* https://bugzilla.suse.com/show_bug.cgi?id=1191846
* https://bugzilla.suse.com/show_bug.cgi?id=1191847