### PR TITLE
Clarify support statement

### DIFF
--- a/xml/cha_introduction.xml
+++ b/xml/cha_introduction.xml
@@ -270,7 +270,7 @@
       </entry>
       <entry>
        <para>
-        by CSP; by &suse; only with priority support
+        by CSP; by &suse; only for SUSE Marketplace listings, meaning listings where the seller in the listing is &suse; 
        </para>
       </entry>
      </row>


### PR DESCRIPTION
For PAYG listings we have 2 types of listings. One where we sell through the CSP and one where SUSE is the seller of record, i.e. we list the product. In the first case the CSP is responsible for L1 & L2 support, in the latter case SUSE covers the full support. Clarify this by changing the wording.