### PR TITLE
Change the log path for registercloudguest command

### DIFF
--- a/xml/cha_administration.xml
+++ b/xml/cha_administration.xml
@@ -306,7 +306,7 @@
    <step>
     <para>
      If the system is registered, check if the file
-     <filename>/var/log/guestregister</filename> exists. This usually indicates
+     <filename>/var/log/cloudregister</filename> exists. This usually indicates
      the system was registered with <command>registercloudguest</command>.
     </para>
    </step>


### PR DESCRIPTION
The command registercloudguest does log the information to /var/log/cloudregister
and the documentation points to /var/log/guestregister which is wrong and needs to be updated