### PR TITLE
doc-kit run (fetch updates)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ build/
 .idea/
 *.code-workspace
 .vimrc
+worktree
+.worktree
+worktrees
+.worktrees

--- a/doc-kit.conf
+++ b/doc-kit.conf
@@ -1,12 +1,12 @@
 type: docbook5-book
 variant: license-gfdl
 
-file: d5aba8356449342d0bac0a62116b85f1b44ee73d  .gitignore
+file: ff3dfe8d7e05c08517d1b055b278bbc9f7e0aa01  .gitignore
 file: c6b4745307e90c9b88905b434cbbaddc54e4541b  .editorconfig
-file: f2c87ac37c4c5e9f0e26945fb58e7c63a22bb35d  xml/generic-entities.ent
+file: 078c37d26e1a91c41b1689f88b4e006929c134c4  xml/generic-entities.ent
 file: a79a3bc929478668955564bab48aecc8502555f6  xml/network-entities.ent
 file: 42fafc60a5e9622a138cede94d63a5b0bdc118c1  xml/common_intro_available_doc.xml
-file: 6b82b8fa32f3c8cd8c76e804e420ae4a9312ec27  xml/common_intro_support.xml
+file: ee8dbf17324e3e72b54bcb6fcc5dec7f7e4e1e9b  xml/common_intro_support.xml
 file: 0e30d909a3d9305a496f3aecf3aa981f3f16f465  xml/common_intro_convention.xml
 file: 2af06d76aa36c3a85968e56e24440d56926cf81b  xml/common_intro_feedback.xml
 file: 9f5f8165bfa8b076d80107d811b89c6c6bded8dd  xml/common_copyright_gfdl.xml

--- a/xml/generic-entities.ent
+++ b/xml/generic-entities.ent
@@ -44,6 +44,7 @@
 <!ENTITY prompt.root            "<prompt role='root' xmlns='http://docbook.org/ns/docbook'># </prompt>">
 <!ENTITY prompt.user            "<prompt xmlns='http://docbook.org/ns/docbook'>&gt; </prompt>">
 <!ENTITY prompt.sudo            "<prompt xmlns='http://docbook.org/ns/docbook'>&gt; </prompt><command xmlns='http://docbook.org/ns/docbook'>sudo</command> ">
+<!ENTITY prompt.tr-up           "<prompt role='root' xmlns='http://docbook.org/ns/docbook'>transactional update # </prompt>">
 
 
 
@@ -56,9 +57,21 @@
 
 <!-- SUSE PRODUCTS -->
 
-<!ENTITY sliberty               "&suse; Liberty Linux">
-<!ENTITY neuvector              "NeuVector">
-<!ENTITY ranchelemental         "Rancher Elemental">
+<!ENTITY sliberty               "&suse; Multi-Linux Support">
+<!ENTITY neuvector              "&ssecurity;">
+<!ENTITY sobservability         "&suse; Observability">
+<!ENTITY ssecurity              "&suse; Security">
+<!ENTITY sstorage               "&suse; Storage">
+<!ENTITY svirtualization        "&suse; Virtualization">
+<!ENTITY sappco                 "&suse; Application Collection">
+<!ENTITY ranchelemental         "&rancherprime;: OS Manager">
+<!ENTITY ailibrary              "AI Library">
+<!ENTITY suseaisuite            "&suse; AI Suite">
+<!ENTITY suseai                 "&suse; AI">
+<!ENTITY rke2                   "&rancherprime;: RKE2">
+<!ENTITY ranchermanager         "&rancherprime;">
+<!ENTITY rancherappco           "&rancherprime; Application Collection">
+<!ENTITY rancherprime           "&suse; Rancher Prime">
 
 <!-- SLE -->
 <!ENTITY jeos                   "JeOS"><!-- Just enough OS -->
@@ -76,7 +89,7 @@
 <!ENTITY sdk                    "&suse; Software Development Kit">
 <!ENTITY sles                   "&sle; Server">
 <!ENTITY sls                    "&sles;">
-<!ENTITY sles4sap               "&sls; for &sap; Applications">
+<!ENTITY sles4sap               "&sls; for &sap; applications">
 <!ENTITY s4s                    "&sles4sap;">
 <!ENTITY slem                   "&sle; Micro">
 <!ENTITY bci-product            "&slea; Base Container Images">
@@ -93,12 +106,11 @@
 <!ENTITY hageo                  "Geo Clustering for &sleha;">
 
 
-<!-- SUSE Manager -->
-<!ENTITY susemgr                "&suse; Manager">
-<!ENTITY suma                   "&susemgr;">
-<!ENTITY susemgrdb              "&suse; Manager with Database">
-<!ENTITY susemgrproxy           "&susemgr; Proxy">
-<!ENTITY smr                    "&susemgr; for Retail">
+<!-- SUSE Multi-Linux Manager -->
+
+<!ENTITY smlm             "&suse; Multi-Linux Manager">
+<!ENTITY smlm-proxy       "&smlm; Proxy">
+<!ENTITY smlm-retail      "&smlm; for Retail">
 
 
 <!-- SUSE PRODUCT ACRONYMS (as approved in TermWeb 2023) -->
@@ -122,8 +134,7 @@
 <!ENTITY capa                   "SUSE&nbsp;CAP">
 <!ENTITY caaspa                 "SUSE&nbsp;CaaSP">
 <!ENTITY caspa                  "&caaspa;">
-<!ENTITY sumaa                  "SUMA">
-<!ENTITY smra                   "SUMA&nbsp;for&nbsp;Retail">
+<!ENTITY suseaia                "&suse; AI">
 
 
 <!-- PRODUCT NAMES WITH (R) SIGN (incomplete) -->
@@ -133,7 +144,7 @@
 <!ENTITY slehpcreg              "&slereg; High Performance Computing">
 <!ENTITY slertreg               "&slereg; Real Time">
 <!ENTITY slsreg                 "&slereg; Server">
-<!ENTITY sles4sapreg            "&slsreg; for &sap; Applications">
+<!ENTITY sles4sapreg            "&slsreg; for &sap; applications">
 <!ENTITY slemreg                "&slereg; Micro">
 <!ENTITY susemgrreg             "&suse;&reg; Manager">
 
@@ -179,6 +190,7 @@ use &deng;! -->
 <!ENTITY ms                     "Microsoft">
 <!ENTITY msreg                  "<trademark xmlns='http://docbook.org/ns/docbook' class='registered'>&ms;</trademark>">
 <!ENTITY nvidia                 "NVIDIA">
+<!ENTITY nvidiareg              "&nvidia;*">
 <!ENTITY rh                     "Red Hat">
 <!ENTITY redhat                 "&rh;">
 <!ENTITY sap                    "SAP">
@@ -200,8 +212,33 @@ use &deng;! -->
 <!ENTITY rhla                   "RHEL">
 <!ENTITY rpios                  "Raspberry&nbsp;Pi&nbsp;OS">
 <!ENTITY centos                 "CentOS">
+<!ENTITY stackstate             "StackState">
+<!ENTITY ollama                 "Ollama">
+<!ENTITY owui                   "Open WebUI">
+<!ENTITY milvus                 "Milvus">
+<!ENTITY chromadb               "ChromaDB">
+<!ENTITY helm                   "Helm">
+<!ENTITY nvoperator             "&nvidia; GPU Operator">
+<!ENTITY containerd             "containerd">
+<!ENTITY langchain              "LangChain">
+<!ENTITY apulsar                "Apache Pulsar">
+<!ENTITY etcd                   "etcd">
+<!ENTITY minio                  "MinIO">
+<!ENTITY okta                   "Okta">
+<!ENTITY certmanager            "cert-manager">
 
 
+<!-- NVIDIA products -->
+<!ENTITY cuda                   "CUDA">
+<!ENTITY cudareg                "&cuda;*">
+<!ENTITY jetson                 "Jetson">
+<!ENTITY jetsonreg              "&jetson;*">
+<!ENTITY jetpack                "JetPack">
+<!ENTITY jetpackreg             "&jetpack;*">
+<!ENTITY xavier                 "Xavier">
+<!ENTITY xavierreg              "&xavier;*">
+<!ENTITY orin                   "Orin">
+<!ENTITY orinreg                "&orin;*">
 
 <!-- SLE DVD IMAGE NAMES -->
 
@@ -285,7 +322,7 @@ use &deng;! -->
 <!ENTITY kprobes                "Kprobes">
 <!ENTITY krb                    "Kerberos">
 <!ENTITY kube                   "Kubernetes">
-<!ENTITY k3s                    "K3s">
+<!ENTITY k3s                    "&rancherprime;: K3s">
 <!ENTITY kubevirt               "KubeVirt">
 <!ENTITY libo                   "LibreOffice">
 <!ENTITY lvmcache               "<systemitem xmlns='http://docbook.org/ns/docbook' class='resource'>lvmcache</systemitem>">
@@ -466,6 +503,7 @@ use &deng;! -->
 <!-- NETWORK PROTOCOLS -->
 <!ENTITY ptp             "Precision Time Protocol">
 <!ENTITY ntp             "Network Time Protocol">
+<!ENTITY nts             "Network Time Security">
 
 
 <!-- Security -->
@@ -522,7 +560,7 @@ use &deng;! -->
 <!ENTITY sle_container_guide    "Container Guide">
 <!ENTITY sle_pcidss_guide       "&pcidss; (&pcidssa;) Guide">
 <!ENTITY sle_pcidss_guide_a     "&pcidssa; Guide">
-<!ENTITY hpc_guide              "HPC Guide">
+<!ENTITY hpc_guide              "&hpc; Guide">
 
 
 <!-- SLE Micro-specific -->
@@ -604,6 +642,17 @@ use &deng;! -->
 <!ENTITY susefirewall           "SuSEfirewall2">
 <!ENTITY susefirewallfiles      "SuSEfirewall2">
 <!ENTITY mysql                  "&mariadb;">
+
+
+<!-- SUSE Manager -->
+<!ENTITY susemgr                "&suse; Manager">
+<!ENTITY suma                   "&susemgr;">
+<!ENTITY susemgrdb              "&suse; Manager with Database">
+<!ENTITY susemgrproxy           "&susemgr; Proxy">
+<!ENTITY smr                    "&susemgr; for Retail">
+<!ENTITY sumaa                  "SUMA">
+<!ENTITY smra                   "SUMA&nbsp;for&nbsp;Retail">
+
 
 <!--SUSE Manager, old guide names -->
 <!ENTITY mgrclientconfguide     "Client Configuration Guide">


### PR DESCRIPTION
@cwickert : This PR contains a doc-kit run to fetch the latest updates for the files that are managed by doc-kit. 

The `generic-entities.ent` also provides you with the recent productname updates, the major ones being:

- 'SUSE Manager' to 'SUSE Multi-Linux Manager' (note: I did _not_ change the values of existing SuMa entities (as for our versioned docs we still need the old product name in our maintenance branches), but added new entities for SMLM. To start using the new product name in the Public Cloud docs, you need to replace any `susemgr/suma/*` entities used within your XML files with the new `smlm*` entities). 

- SUSE Liberty Linux to SUSE Multi-Linux Support (in that case I _changed_  the value of the existing entity `sliberty` as Tahlia has also updated the productname in her docs in all Liberty maintenance branches as the number of branches was small).

- 'SUSE Linux Enterprise for SAP Applications' to 'SUSE Linux Enterprise for SAP applications' (this change needs to be reflected across all our docs, therefore we have changed the value of the respective entity). 
  