### PR TITLE
Remove regionServiceCertsCSP from the documentation

### DIFF
--- a/xml/cha_administration.xml
+++ b/xml/cha_administration.xml
@@ -180,19 +180,19 @@
                For &ec2a; run:
              </para>
 <screen>&prompt.root;<command>zypper</command> in cloud-regionsrv-client cloud-regionsrv-client-plugin-ec2 \
- regionServiceClientConfigEC2 regionServiceCertsEC2</screen>
+ regionServiceClientConfigEC2</screen>
            </step>
            <step>
              <para>
                For &azure; run:
              </para>
 <screen>&prompt.root;<command>zypper</command> in cloud-regionsrv-client cloud-regionsrv-client-plugin-azure \
- regionServiceClientConfigAzure regionServiceCertsAzure</screen>
+ regionServiceClientConfigAzure</screen>
            </step>
            <step>
              <para>For &gce; run:</para>
 <screen>&prompt.root;<command>zypper</command> in cloud-regionsrv-client cloud-regionsrv-client-plugin-gce \
- regionServiceClientConfigGCE regionServiceCertsGCE</screen>
+ regionServiceClientConfigGCE</screen>
            </step>
          </stepalternatives>
        </step>


### PR DESCRIPTION
when switching from SUSEConnect to registercloudguest instructions, the package regionServiceCerts<CSP> should not be included in the list of zypper in packages as the package is not a client package

it is not installed in the images and they will not have access to install it unless registered to SCC or other approaches

This Fixes bsc#1241995